### PR TITLE
feat: add verbose flag on create-unik command

### DIFF
--- a/packages/uns-cli/src/baseCommandLogs.ts
+++ b/packages/uns-cli/src/baseCommandLogs.ts
@@ -1,0 +1,20 @@
+import { BaseCommand } from "./baseCommand";
+
+/**
+ * Temporary abstract class to override log function only for some commands. A command that use verbose flag should extend BaseCommandLog
+ * After migration of all commands to verbose mode (loggers), we should remove this class and override log function in BaseCommand. All commands will extend BaseCommand
+ */
+export abstract class BaseCommandLogs extends BaseCommand {
+    /**
+     * Enables this.log on every BaseCommandLogs sub commands
+     */
+    public log(message?: string, ...args: any[]): void {
+        if (this.verbose) {
+            if (args && args.length > 0) {
+                super.log(message, args);
+            } else {
+                super.log(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**1 reviewer**

## Summary
Adds verbose flag for all commands.
Use verbose and refactor loggers

## What kind of change does this PR introduce?

-   [ ] Bugfix
-   [x] New feature
-   [ ] Refactoring / Performance Improvements
-   [ ] Build-related changes
-   [ ] Documentation
-   [ ] Tests / Continuous Integration
-   [ ] Other, please describe:

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

## Does this PR release a new version?

-   [ ] Yes
    -   [ ] All tests are passing
    -   [ ] All benchmarks are passing without any _major_ regressions
    -   [ ] Sync from 0 works on mainnet
    -   [ ] Sync from 0 works on devnet
    -   [ ] Starting a new network and forging on it work
    -   [ ] Explorer is fully functional
    -   [ ] Wallets are fully functional
-   [x] No
