### PR TITLE
build: force docker volume name for testnet

### DIFF
--- a/scripts/docker/templates/testnet/docker-compose.yml
+++ b/scripts/docker/templates/testnet/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.7'
 services:
 
   postgres:
@@ -36,7 +36,9 @@ services:
 
 volumes:
   postgres:
+    name: testnet_postgres_{token}
   core:
+    name: testnet_core_{token}
     driver_opts:
       type: none
       device: $PWD/../../../


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
This commit force the docker volume name to be suffixed by the token name.
This aim to avoid conflict of docker volumes having the same name.
This happen when you maintain two different branch using same docker architecture ( for exemple unsing git worktree for uns-core<feat/nft> and uns-core<private/develop>.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Bugfix
-   [ ] New feature
-   [ ] Refactoring / Performance Improvements
-   [ ] Build-related changes
-   [ ] Documentation
-   [ ] Tests / Continuous Integration
-   [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
-   [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
    -   [ ] All tests are passing
    -   [ ] All benchmarks are passing without any _major_ regressions
    -   [ ] Sync from 0 works on mainnet
    -   [ ] Sync from 0 works on devnet
    -   [ ] Starting a new network and forging on it work
    -   [ ] Explorer is fully functional
    -   [ ] Wallets are fully functional
-   [ ] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
-   [ ] Lint and unit tests pass locally with my changes
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
