### PR TITLE
feat: add unset-properties command + flags refactoring

### DIFF
--- a/packages/uns-cli/src/baseCommand.ts
+++ b/packages/uns-cli/src/baseCommand.ts
@@ -145,7 +145,7 @@ export abstract class BaseCommand extends Command {
         expectedConfirmations: number = 0,
     ) {
         const transactionFromNetwork = await this.api.getTransaction(transactionId, blockTime * 1000);
-        const confirmations = transactionFromNetwork.confirmations;
+        const confirmations = transactionFromNetwork ? transactionFromNetwork.confirmations : 0;
         if (confirmations < expectedConfirmations && numberOfRetry > 0) {
             return await this.waitTransactionConfirmations(
                 blockTime,

--- a/packages/uns-cli/src/commands/get-properties.ts
+++ b/packages/uns-cli/src/commands/get-properties.ts
@@ -1,7 +1,7 @@
 import { flags } from "@oclif/command";
 import { BaseCommand } from "../baseCommand";
 import { CommandOutput, Formater, NestedCommandOutput, OUTPUT_FORMAT } from "../formater";
-import { getNetworksListListForDescription } from "../utils";
+import { getNetworksListListForDescription, unikidFlag } from "../utils";
 
 export class GetPropertiesCommand extends BaseCommand {
     public static description = "Get properties of UNIK token.";
@@ -13,10 +13,7 @@ export class GetPropertiesCommand extends BaseCommand {
 
     public static flags = {
         ...BaseCommand.baseFlags,
-        unikid: flags.string({
-            description: "The UNIK token on which to get the properties.",
-            required: true,
-        }),
+        ...unikidFlag("The UNIK token on which to get the properties."),
         confirmed: flags.integer({
             default: 3,
             description:

--- a/packages/uns-cli/src/commands/read-unik.ts
+++ b/packages/uns-cli/src/commands/read-unik.ts
@@ -2,7 +2,7 @@ import { flags } from "@oclif/command";
 import { BaseCommand } from "../baseCommand";
 import { Formater, NestedCommandOutput, OUTPUT_FORMAT } from "../formater";
 import { ReadCommand } from "../readCommand";
-import { getNetworksListListForDescription } from "../utils";
+import { getNetworksListListForDescription, unikidFlag } from "../utils";
 
 export class ReadUnikCommand extends ReadCommand {
     public static description = "Display UNIK token informations";
@@ -13,7 +13,7 @@ export class ReadUnikCommand extends ReadCommand {
 
     public static flags = {
         ...ReadCommand.baseFlags,
-        unikid: flags.string({ description: "Token id to read", required: true }),
+        ...unikidFlag("Token id to read"),
     };
 
     protected getAvailableFormats(): Formater[] {

--- a/packages/uns-cli/src/commands/set-properties.ts
+++ b/packages/uns-cli/src/commands/set-properties.ts
@@ -1,18 +1,12 @@
 import { flags } from "@oclif/parser";
 import { BaseCommand } from "../baseCommand";
-import { CommandOutput, Formater, OUTPUT_FORMAT } from "../formater";
-import {
-    checkPassphraseFormat,
-    checkUnikIdFormat,
-    createNFTUpdateTransaction,
-    getNetworksListListForDescription,
-    getPassphraseFromUser,
-    passphraseFlag,
-} from "../utils";
+import { Formater, OUTPUT_FORMAT } from "../formater";
+import { UpdateProperties as UpdatePropertiesCommand } from "../updatePropertiesCommand";
+import { getNetworksListListForDescription } from "../utils";
 
 const KEY_VALUE_SEPARATOR = ":";
 
-export class SetPropertiesCommand extends BaseCommand {
+export class SetPropertiesCommand extends UpdatePropertiesCommand {
     public static description = "Set (add or update) properties of UNIK token.";
 
     public static examples = [
@@ -21,32 +15,12 @@ export class SetPropertiesCommand extends BaseCommand {
     ];
 
     public static flags = {
-        ...BaseCommand.baseFlags,
-        unikid: flags.string({
-            description: "The UNIK token on which to set the properties.",
-            required: true,
-        }),
+        ...UpdatePropertiesCommand.flags,
         properties: flags.string({
             description: `Array of properties to set: "key1:value1"
                 "key3:" Sets "value1" to "key1" and empty string to "key3"`,
             required: true,
             multiple: true,
-        }),
-        await: flags.integer({
-            description: `Number of blocks to wait to get confirmed for the success. Default to 3.
-                0 for immediate return.
-                Needs to be strictly greater than --confirmation flag`,
-            default: 3,
-        }),
-        confirmations: flags.integer({
-            description:
-                "Number of confirmations to wait to get confirmed for the success. Default to 1.\n\t Needs to be strictly lower than --await flag",
-            default: 1,
-        }),
-        ...passphraseFlag,
-        fee: flags.integer({
-            description: "Specify a dynamic fee in satoUNS. Defaults to 100000000 satoUNS = 1 UNS.",
-            default: 100000000,
         }),
     };
 
@@ -62,65 +36,9 @@ export class SetPropertiesCommand extends BaseCommand {
         return "set-properties";
     }
 
-    protected async do(flags: Record<string, any>): Promise<CommandOutput> {
-        // Check flags consistency
-        if (flags.await <= flags.confirmations) {
-            throw new Error(
-                `Flags consistency error. --await (${flags.await}) should be strictly higher than --confirmations (${
-                    flags.confirmations
-                })`,
-            );
-        }
-
-        // Check unikid format
-        checkUnikIdFormat(flags.unikid);
-
-        // Parse properties
-        const properties: { [_: string]: string } = this.parseProperties(flags.properties);
-
-        // Get passphrase
-        let passphrase = flags.passphrase;
-        if (!passphrase) {
-            passphrase = await getPassphraseFromUser();
-        }
-
-        // Check passphrase format
-        checkPassphraseFormat(passphrase);
-
-        // Update transaction
-        const transactionStruct = createNFTUpdateTransaction(
-            this.client,
-            flags.unikid,
-            properties,
-            flags.fee,
-            this.api.getVersion(),
-            passphrase,
-        );
-
-        this.log("Binding new propert" + (Object.keys(properties).length > 1 ? "ies" : "y") + " to UNIK.");
-        const sendResult = await this.api.sendTransaction(transactionStruct);
-        if (sendResult.errors) {
-            throw new Error(`Transaction not accepted. Caused by: ${JSON.stringify(sendResult.errors)}`);
-        }
-        this.actionStart("Waiting for transaction confirmation");
-        const finalTransaction = await this.waitTransactionConfirmations(
-            this.api.getBlockTime(),
-            transactionStruct.id,
-            flags.await,
-            flags.confirmations,
-        );
-        this.actionStop();
-
-        return {
-            id: flags.unikid,
-            transaction: finalTransaction.id,
-            confirmations: finalTransaction.confirmations,
-        };
-    }
-
-    private parseProperties(props: string[]): { [_: string]: string } {
+    protected getProperties(flags: Record<string, any>): { [_: string]: string } {
         const properties: { [_: string]: string } = {};
-        for (const prop of props) {
+        for (const prop of flags.properties) {
             const firstSeparatorIndex = prop.indexOf(KEY_VALUE_SEPARATOR);
             if (firstSeparatorIndex === -1) {
                 throw new Error(`Property ${prop}, doesn't contain ${KEY_VALUE_SEPARATOR}`);

--- a/packages/uns-cli/src/commands/unset-properties.ts
+++ b/packages/uns-cli/src/commands/unset-properties.ts
@@ -1,0 +1,45 @@
+import { flags } from "@oclif/parser";
+import { BaseCommand } from "../baseCommand";
+import { Formater, OUTPUT_FORMAT } from "../formater";
+import { UpdateProperties } from "../updatePropertiesCommand";
+import { getNetworksListListForDescription } from "../utils";
+
+export class UnsetProperties extends UpdateProperties {
+    public static description = "Unset properties of UNIK token.";
+
+    public static examples = [
+        `$ uns unset-properties --network ${getNetworksListListForDescription()} --unkid {unikId}
+        -k prop1 -k prop2 --format {json|yaml} --verbose`,
+    ];
+
+    public static flags = {
+        ...UpdateProperties.flags,
+        propertyKey: flags.string({
+            char: "k",
+            description: "Key of the property to unset. (multiple occurrences)",
+            required: true,
+            multiple: true,
+        }),
+    };
+
+    protected getAvailableFormats(): Formater[] {
+        return [OUTPUT_FORMAT.json, OUTPUT_FORMAT.yaml];
+    }
+
+    protected getCommand(): typeof BaseCommand {
+        return UnsetProperties;
+    }
+
+    protected getCommandTechnicalName(): string {
+        return "set-properties";
+    }
+
+    protected getProperties(flags: Record<string, any>): { [_: string]: string } {
+        const properties: { [_: string]: string } = {};
+
+        flags.propertyKey.forEach(prop => {
+            properties[prop] = null;
+        });
+        return properties;
+    }
+}

--- a/packages/uns-cli/src/updatePropertiesCommand.ts
+++ b/packages/uns-cli/src/updatePropertiesCommand.ts
@@ -1,0 +1,72 @@
+import { BaseCommand } from "./baseCommand";
+import { CommandOutput } from "./formater";
+import {
+    awaitFlag,
+    checkPassphraseFormat,
+    checkUnikIdFormat,
+    confirmationsFlag,
+    createNFTUpdateTransaction,
+    feeFlag,
+    getPassphraseFromUser,
+    passphraseFlag,
+    unikidFlag,
+} from "./utils";
+
+export abstract class UpdateProperties extends BaseCommand {
+    public static flags = {
+        ...BaseCommand.baseFlags,
+        ...unikidFlag("The UNIK token on which to update the properties."),
+        ...awaitFlag,
+        ...confirmationsFlag,
+        ...passphraseFlag,
+        ...feeFlag,
+    };
+
+    protected abstract getProperties(flags: Record<string, any>): { [_: string]: string };
+
+    protected async do(flags: Record<string, any>): Promise<CommandOutput> {
+        // Check unikid format
+        checkUnikIdFormat(flags.unikid);
+
+        // Get passphrase
+        let passphrase = flags.passphrase;
+        if (!passphrase) {
+            passphrase = await getPassphraseFromUser();
+        }
+
+        // Check passphrase format
+        checkPassphraseFormat(passphrase);
+
+        const properties = this.getProperties(flags);
+
+        // Update transaction
+        const transactionStruct = createNFTUpdateTransaction(
+            this.client,
+            flags.unikid,
+            properties,
+            flags.fee,
+            this.api.getVersion(),
+            passphrase,
+        );
+
+        this.log("Binding new propert" + (Object.keys(properties).length > 1 ? "ies" : "y") + " to UNIK.");
+        const sendResult = await this.api.sendTransaction(transactionStruct);
+        if (sendResult.errors) {
+            throw new Error(`Transaction not accepted. Caused by: ${JSON.stringify(sendResult.errors)}`);
+        }
+        this.actionStart("Waiting for transaction confirmation");
+        const finalTransaction = await this.waitTransactionConfirmations(
+            this.api.getBlockTime(),
+            transactionStruct.id,
+            flags.await,
+            flags.confirmations,
+        );
+        this.actionStop();
+
+        return {
+            id: flags.unikid,
+            transaction: transactionStruct.id,
+            confirmations: finalTransaction ? finalTransaction.confirmations : 0,
+        };
+    }
+}

--- a/packages/uns-cli/src/utils.ts
+++ b/packages/uns-cli/src/utils.ts
@@ -96,3 +96,36 @@ export const passphraseFlag = {
             "The passphrase of the owner of UNIK. If you do not enter a passphrase you will be prompted for it.",
     }),
 };
+
+export const awaitFlag = {
+    await: flags.integer({
+        description: `Number of blocks to wait to get confirmed for the success. Default to 3.
+            0 for immediate return.
+            Needs to be strictly greater than --confirmation flag`,
+        default: 3,
+    }),
+};
+
+export const confirmationsFlag = {
+    confirmations: flags.integer({
+        description:
+            "Number of confirmations to wait to get confirmed for the success. Default to 1.\n\t Needs to be strictly lower than --await flag",
+        default: 1,
+    }),
+};
+
+export const feeFlag = {
+    fee: flags.integer({
+        description: "Specify a dynamic fee in satoUNS. Defaults to 100000000 satoUNS = 1 UNS.",
+        default: 100000000,
+    }),
+};
+
+export const unikidFlag = (description?: string) => {
+    return {
+        unikid: flags.string({
+            description,
+            required: true,
+        }),
+    };
+};


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

- add unset-properties command [#1410](https://spacelephant.tpondemand.com/restui/board.aspx?#page=board/4832170605429899055&appConfig=eyJhY2lkIjoiRjdBMEY0NkNFQzU3NjY3MThBQkQ2RDkwODEzQzU1MzMifQ==&boardPopup=userstory/1190)
- flags refactoring

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Bugfix
-   [x] New feature
-   [x] Refactoring / Performance Improvements
-   [ ] Build-related changes
-   [ ] Documentation
-   [ ] Tests / Continuous Integration
-   [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
-   [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
    -   [ ] All tests are passing
    -   [ ] All benchmarks are passing without any _major_ regressions
    -   [ ] Sync from 0 works on mainnet
    -   [ ] Sync from 0 works on devnet
    -   [ ] Starting a new network and forging on it work
    -   [ ] Explorer is fully functional
    -   [ ] Wallets are fully functional
-   [x] No

