### PR TITLE
feat: add fee flag on create-unik command

### DIFF
--- a/packages/uns-cli/src/commands/create-unik.ts
+++ b/packages/uns-cli/src/commands/create-unik.ts
@@ -1,5 +1,5 @@
 import { flags } from "@oclif/command";
-import { ITransactionData } from "@uns/crypto";
+import { constants, ITransactionData } from "@uns/crypto";
 import { BaseCommand } from "../baseCommand";
 import { Formater, NestedCommandOutput, OUTPUT_FORMAT } from "../formater";
 import { getTypeValue, getUnikTypesList } from "../types";
@@ -9,8 +9,9 @@ import {
     getPassphraseFromUser,
     passphraseFlag,
 } from "../utils";
+import { WriteCommand } from "../writeCommand";
 
-export class CreateUnikCommand extends BaseCommand {
+export class CreateUnikCommand extends WriteCommand {
     public static description = "Create UNIK token";
 
     public static examples = [
@@ -20,7 +21,7 @@ export class CreateUnikCommand extends BaseCommand {
     ];
 
     public static flags = {
-        ...BaseCommand.baseFlags,
+        ...WriteCommand.flags,
         explicitValue: flags.string({ description: "UNIK nft token explicit value", required: true }),
         type: flags.string({
             description: "UNIK nft type",
@@ -67,6 +68,7 @@ export class CreateUnikCommand extends BaseCommand {
             this.client,
             tokenId,
             getTypeValue(flags.type),
+            flags.fee,
             passphrase,
             this.api.getVersion(),
         );

--- a/packages/uns-cli/src/updatePropertiesCommand.ts
+++ b/packages/uns-cli/src/updatePropertiesCommand.ts
@@ -1,4 +1,3 @@
-import { BaseCommand } from "./baseCommand";
 import { CommandOutput } from "./formater";
 import {
     awaitFlag,
@@ -6,20 +5,19 @@ import {
     checkUnikIdFormat,
     confirmationsFlag,
     createNFTUpdateTransaction,
-    feeFlag,
     getPassphraseFromUser,
     passphraseFlag,
     unikidFlag,
 } from "./utils";
+import { WriteCommand } from "./writeCommand";
 
-export abstract class UpdateProperties extends BaseCommand {
+export abstract class UpdateProperties extends WriteCommand {
     public static flags = {
-        ...BaseCommand.baseFlags,
+        ...WriteCommand.flags,
         ...unikidFlag("The UNIK token on which to update the properties."),
         ...awaitFlag,
         ...confirmationsFlag,
         ...passphraseFlag,
-        ...feeFlag,
     };
 
     protected abstract getProperties(flags: Record<string, any>): { [_: string]: string };

--- a/packages/uns-cli/src/utils.ts
+++ b/packages/uns-cli/src/utils.ts
@@ -32,6 +32,7 @@ export const createNFTMintTransaction = (
     client: Client,
     tokenId: string,
     tokenType: string,
+    fee: number,
     passphrase: string,
     networkVerion: number,
 ): ITransactionData => {
@@ -39,7 +40,7 @@ export const createNFTMintTransaction = (
         .getBuilder()
         .nftMint(tokenId)
         .properties({ type: tokenType })
-        .fee(client.getFeeManager().get(constants.TransactionTypes.NftTransfer))
+        .fee(fee)
         .network(networkVerion)
         .sign(passphrase)
         .getStruct();
@@ -114,11 +115,13 @@ export const confirmationsFlag = {
     }),
 };
 
-export const feeFlag = {
-    fee: flags.integer({
-        description: "Specify a dynamic fee in satoUNS. Defaults to 100000000 satoUNS = 1 UNS.",
-        default: 100000000,
-    }),
+export const feeFlag = (defaultFee: number = 100000000): { [_: string]: flags.IOptionFlag<number> } => {
+    return {
+        fee: flags.integer({
+            description: `Specify a dynamic fee in satoUNS. Defaults to ${defaultFee} (100000000 satoUNS = 1 UNS).`,
+            default: defaultFee,
+        }),
+    };
 };
 
 export const unikidFlag = (description?: string) => {

--- a/packages/uns-cli/src/writeCommand.ts
+++ b/packages/uns-cli/src/writeCommand.ts
@@ -1,0 +1,9 @@
+import { BaseCommand } from "./baseCommand";
+import { feeFlag } from "./utils";
+
+export abstract class WriteCommand extends BaseCommand {
+    public static flags = {
+        ...BaseCommand.baseFlags,
+        ...feeFlag(),
+    };
+}


### PR DESCRIPTION
Create WriteCommand

<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

- add fee flag on create-unik command [#1380](https://spacelephant.tpondemand.com/restui/board.aspx?#page=board/4832170605429899055&appConfig=eyJhY2lkIjoiRjdBMEY0NkNFQzU3NjY3MThBQkQ2RDkwODEzQzU1MzMifQ==&boardPopup=userstory/1379)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->
- create Write command to add fee flage on each write command (unset-properties, set-properties and create-unik)

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Bugfix
-   [x] New feature
-   [ ] Refactoring / Performance Improvements
-   [ ] Build-related changes
-   [ ] Documentation
-   [ ] Tests / Continuous Integration
-   [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
-   [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
    -   [ ] All tests are passing
    -   [ ] All benchmarks are passing without any _major_ regressions
    -   [ ] Sync from 0 works on mainnet
    -   [ ] Sync from 0 works on devnet
    -   [ ] Starting a new network and forging on it work
    -   [ ] Explorer is fully functional
    -   [ ] Wallets are fully functional
-   [x] No
