### PR TITLE
feat: add chainmeta flag on read commands

### DIFF
--- a/packages/uns-cli/README.md
+++ b/packages/uns-cli/README.md
@@ -137,6 +137,7 @@ USAGE
 OPTIONS
   -f, --format=json|yaml  [default: json] Specify how to format the output [json|yaml].
   -h, --help              show CLI help
+  --chainmeta             Retrieve chain meta data
   --network=devnet|local  (required) Network used to create UNIK nft token (local are for development only)
   --unikid=unikid         (required) Token id to read
   --verbose               Detailed logs
@@ -158,6 +159,7 @@ USAGE
 OPTIONS
   -f, --format=json|yaml  [default: json] Specify how to format the output [json|yaml].
   -h, --help              show CLI help
+  --chainmeta             Retrieve chain meta data
   --idwallet=idwallet     (required) The ID of the wallet. Can be either the publicKey or the address of the wallet.
   --listunik              List UNIK tokens owned by the wallet, if any.
   --network=devnet|local  (required) Network used to create UNIK nft token (local are for development only)

--- a/packages/uns-cli/src/commands/read-unik.ts
+++ b/packages/uns-cli/src/commands/read-unik.ts
@@ -12,7 +12,7 @@ export class ReadUnikCommand extends ReadCommand {
     ];
 
     public static flags = {
-        ...ReadCommand.baseFlags,
+        ...ReadCommand.flags,
         ...unikidFlag("Token id to read"),
     };
 
@@ -39,7 +39,7 @@ export class ReadUnikCommand extends ReadCommand {
             creationTransaction.chainmeta.height,
         );
 
-        const result = {
+        const data = {
             id: unik.id,
             ownerAddress: unik.ownerId,
             creationBlock: creationTransaction.blockId,
@@ -49,8 +49,8 @@ export class ReadUnikCommand extends ReadCommand {
         };
 
         return {
-            data: result,
-            ...this.showContext(unik.chainmeta),
+            data,
+            ...(flags.chainmeta ? this.showContext(unik.chainmeta) : {}),
         };
     }
 }

--- a/packages/uns-cli/src/commands/read-wallet.ts
+++ b/packages/uns-cli/src/commands/read-wallet.ts
@@ -12,7 +12,7 @@ export class ReadWalletCommand extends ReadCommand {
     ];
 
     public static flags = {
-        ...ReadCommand.baseFlags,
+        ...ReadCommand.flags,
         idwallet: flags.string({
             description: "The ID of the wallet. Can be either the publicKey or the address of the wallet.",
             required: true,
@@ -64,7 +64,7 @@ export class ReadWalletCommand extends ReadCommand {
 
         return {
             data,
-            ...this.showContext(wallet.chainmeta),
+            ...(flags.chainmeta ? this.showContext(wallet.chainmeta) : {}),
         };
     }
 }

--- a/packages/uns-cli/src/readCommand.ts
+++ b/packages/uns-cli/src/readCommand.ts
@@ -1,7 +1,13 @@
 import { BaseCommand } from "./baseCommand";
 import { ChainMeta } from "./types";
+import { chainmetaFlag } from "./utils";
 
 export abstract class ReadCommand extends BaseCommand {
+    public static flags = {
+        ...BaseCommand.baseFlags,
+        ...chainmetaFlag,
+    };
+
     protected showContext(chainmeta: ChainMeta) {
         /**
          * CONTEXT

--- a/packages/uns-cli/src/utils.ts
+++ b/packages/uns-cli/src/utils.ts
@@ -129,3 +129,10 @@ export const unikidFlag = (description?: string) => {
         }),
     };
 };
+
+export const chainmetaFlag = {
+    chainmeta: flags.boolean({
+        description: "Retrieve chain meta datas",
+        default: false,
+    }),
+};


### PR DESCRIPTION
TP #1419 #1424

<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
- read-wallet command chainmeta flag[#1419](https://spacelephant.tpondemand.com/restui/board.aspx?#page=board/4832170605429899055&appConfig=eyJhY2lkIjoiRjdBMEY0NkNFQzU3NjY3MThBQkQ2RDkwODEzQzU1MzMifQ==&boardPopup=task/1419/silent)
- read-unik command chainmeta flag [#1424](https://spacelephant.tpondemand.com/restui/board.aspx?#page=board/4832170605429899055&appConfig=eyJhY2lkIjoiRjdBMEY0NkNFQzU3NjY3MThBQkQ2RDkwODEzQzU1MzMifQ==&boardPopup=task/1424/silent)
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Bugfix
-   [x] New feature
-   [ ] Refactoring / Performance Improvements
-   [ ] Build-related changes
-   [ ] Documentation
-   [ ] Tests / Continuous Integration
-   [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
-   [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
    -   [ ] All tests are passing
    -   [ ] All benchmarks are passing without any _major_ regressions
    -   [ ] Sync from 0 works on mainnet
    -   [ ] Sync from 0 works on devnet
    -   [ ] Starting a new network and forging on it work
    -   [ ] Explorer is fully functional
    -   [ ] Wallets are fully functional
-   [x] No
