### PR TITLE
feat: limit NFT property value size

### DIFF
--- a/__tests__/unit/core-transactions/handler.test.ts
+++ b/__tests__/unit/core-transactions/handler.test.ts
@@ -910,4 +910,17 @@ describe("NFTUpdateTransaction", () => {
             await expect(handler.canBeApplied(instance, wallet)).rejects.toThrow(ConstraintError);
         });
     });
+
+    describe("NFT properies validation", () => {
+        it("should throw PropertyValueLengthError", async () => {
+            const tooLongProperty = {
+                myProperty:
+                    "💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎",
+            };
+            transaction.asset.nft[configManager.getCurrentNftName()].properties = tooLongProperty;
+            expect(() => {
+                Transaction.fromData(transaction);
+            }).toThrow(`Expected a maximum size of 255 bytes for property value field.`);
+        });
+    });
 });

--- a/packages/crypto/src/errors.ts
+++ b/packages/crypto/src/errors.ts
@@ -147,3 +147,9 @@ export class InvalidMilestoneConfigurationError extends CryptoError {
         super(message);
     }
 }
+
+export class PropertyValueSizeError extends CryptoError {
+    constructor() {
+        super(`Expected a maximum size of 255 bytes for property value field.`);
+    }
+}

--- a/packages/crypto/src/transactions/types/transaction.ts
+++ b/packages/crypto/src/transactions/types/transaction.ts
@@ -5,6 +5,7 @@ import { crypto } from "../../crypto";
 import {
     MalformedTransactionBytesError,
     NotImplementedError,
+    PropertyValueSizeError,
     TransactionSchemaError,
     TransactionVersionError,
 } from "../../errors";
@@ -154,6 +155,16 @@ export abstract class Transaction {
         if (data.type === TransactionTypes.MultiSignature) {
             data.amount = new Bignum(data.amount);
             data.fee = new Bignum(data.fee);
+            return { value: data, error: null };
+        }
+
+        if (data.type === TransactionTypes.NftMint || data.type === TransactionTypes.NftUpdate) {
+            Object.entries(data.asset.nft.unik.properties).map(([key, value]: [string, string]) => {
+                if (value && Buffer.from(value, "utf8").length > 255) {
+                    throw new PropertyValueSizeError();
+                }
+            });
+
             return { value: data, error: null };
         }
 


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
Limit the value of a NFT property to 255 bytes.
adds new custom error
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Bugfix
-   [x] New feature
-   [ ] Refactoring / Performance Improvements
-   [ ] Build-related changes
-   [ ] Documentation
-   [ ] Tests / Continuous Integration
-   [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
-   [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
    -   [ ] All tests are passing
    -   [ ] All benchmarks are passing without any _major_ regressions
    -   [ ] Sync from 0 works on mainnet
    -   [ ] Sync from 0 works on devnet
    -   [ ] Starting a new network and forging on it work
    -   [ ] Explorer is fully functional
    -   [ ] Wallets are fully functional
-   [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
-   [x] Lint and unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
