### PR TITLE
feat: limit NFT property value size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,6 @@ jobs:
             - ./packages/core-vote-report/node_modules
             - ./packages/core-webhooks/node_modules
             - ./packages/crypto/node_modules
-            - ./packages/uns-cli/node_modules
             - ./node_modules
       - run:
           name: Create .core/database directory
@@ -152,7 +151,6 @@ jobs:
             - ./packages/core-vote-report/node_modules
             - ./packages/core-webhooks/node_modules
             - ./packages/crypto/node_modules
-            - ./packages/uns-cli/node_modules
             - ./node_modules
       - run:
           name: Create .core/database directory
@@ -244,7 +242,6 @@ jobs:
             - ./packages/core-vote-report/node_modules
             - ./packages/core-webhooks/node_modules
             - ./packages/crypto/node_modules
-            - ./packages/uns-cli/node_modules
             - ./node_modules
       - run:
           name: Create .core/database directory
@@ -336,7 +333,6 @@ jobs:
             - ./packages/core-vote-report/node_modules
             - ./packages/core-webhooks/node_modules
             - ./packages/crypto/node_modules
-            - ./packages/uns-cli/node_modules
             - ./node_modules
       - run:
           name: Create .core/database directory
@@ -453,7 +449,6 @@ jobs:
             - ./packages/core-vote-report/node_modules
             - ./packages/core-webhooks/node_modules
             - ./packages/crypto/node_modules
-            - ./packages/uns-cli/node_modules
             - ./node_modules
       - run:
           name: Create .core/database directory

--- a/__tests__/unit/core-transactions/handler.test.ts
+++ b/__tests__/unit/core-transactions/handler.test.ts
@@ -910,4 +910,29 @@ describe("NFTUpdateTransaction", () => {
             await expect(handler.canBeApplied(instance, wallet)).rejects.toThrow(ConstraintError);
         });
     });
+
+    describe("NFT properies validation", () => {
+        it("should throw PropertyValueLengthError", async () => {
+            const tooLongProperty = {
+                oneProperty: "toto",
+                oneLongProperty:
+                    "💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎",
+            };
+            transaction.asset.nft[configManager.getCurrentNftName()].properties = tooLongProperty;
+            expect(() => {
+                Transaction.fromData(transaction);
+            }).toThrow(`Value of property oneLongProperty exceed the maximum allowed size of 255 bytes.`);
+        });
+
+        it("should ingest valid transaction", async () => {
+            const property = {
+                myProperty: "💎💎💎💎",
+                myProperty2: "tututu",
+            };
+            transaction.asset.nft[configManager.getCurrentNftName()].properties = property;
+
+            instance = Transaction.fromData(transaction);
+            await expect(handler.canBeApplied(instance, wallet)).resolves.toBeTrue();
+        });
+    });
 });


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary
Limit the value of a NFT property to 255 bytes.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. -->

## What kind of change does this PR introduce?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Bugfix
-   [x] New feature
-   [ ] Refactoring / Performance Improvements
-   [ ] Build-related changes
-   [ ] Documentation
-   [ ] Tests / Continuous Integration
-   [ ] Other, please describe:

## Does this PR introduce a breaking change?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
-   [x] No

## Does this PR release a new version?

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [ ] Yes
    -   [ ] All tests are passing
    -   [ ] All benchmarks are passing without any _major_ regressions
    -   [ ] Sync from 0 works on mainnet
    -   [ ] Sync from 0 works on devnet
    -   [ ] Starting a new network and forging on it work
    -   [ ] Explorer is fully functional
    -   [ ] Wallets are fully functional
-   [x] No

## Checklist

<!-- _Put an `x` in the boxes that apply. Preserve all boxes! -->

-   [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
-   [x] Lint and unit tests pass locally with my changes
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] I have added necessary documentation _(if appropriate)_

<!--
## Other information

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
-->
