### PR TITLE
fix: remove Long convertion as it doesn't work with writeUint64

### DIFF
--- a/packages/uns-crypto/src/crypto/uns-crypto.ts
+++ b/packages/uns-crypto/src/crypto/uns-crypto.ts
@@ -1,6 +1,5 @@
 import { Crypto, Identities } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { IDiscloseDemandCertificationPayload, IDiscloseDemandPayload } from "../";
 
 class UnsCrypto {
@@ -38,12 +37,12 @@ class UnsCrypto {
             buf.writeUint8(payload.type);
             buf.append(payload.iss, "hex");
             buf.append(payload.sub, "hex");
-            buf.writeUint64(Long.fromValue(payload.iat));
+            buf.writeUint64(payload.iat);
         } else {
             buf = new ByteBuffer(32 /*iss*/ + 32 /*sub*/ + 8 /*iat*/, true);
             buf.append(payload.iss, "hex");
             buf.append(payload.sub, "hex");
-            buf.writeUint64(Long.fromValue(payload.iat));
+            buf.writeUint64(payload.iat);
         }
 
         return buf.flip().toBuffer();

--- a/packages/uns-crypto/src/transactions/uns-disclose-explicit/uns-disclose-explicit.ts
+++ b/packages/uns-crypto/src/transactions/uns-disclose-explicit/uns-disclose-explicit.ts
@@ -1,6 +1,5 @@
 import { Transactions, Utils } from "@arkecosystem/crypto";
 import ByteBuffer from "bytebuffer";
-import Long from "long";
 import { UnsTransactionGroup, UnsTransactionStaticFees, UnsTransactionType } from "../../enums";
 import { IDiscloseDemand, IDiscloseDemandCertification } from "../../interfaces";
 import { unsDiscloseDemand } from "./schema";
@@ -56,12 +55,12 @@ export class DiscloseExplicitTransaction extends Transactions.Transaction {
         buffer.writeUint8(discloseDemand.payload.type);
         buffer.append(discloseDemand.payload.iss, "hex");
         buffer.append(discloseDemand.payload.sub, "hex");
-        buffer.writeUint64(Long.fromValue(discloseDemand.payload.iat));
+        buffer.writeUint64(discloseDemand.payload.iat);
         buffer.append(discloseDemand.signature, "hex");
 
         buffer.append(discloseDemandCert.payload.sub, "hex");
         buffer.append(discloseDemandCert.payload.iss, "hex");
-        buffer.writeUint64(Long.fromValue(discloseDemandCert.payload.iat));
+        buffer.writeUint64(discloseDemandCert.payload.iat);
         buffer.append(discloseDemandCert.signature, "hex");
 
         return buffer;


### PR DESCRIPTION
- remove Long conversion from number as it doesn't work with serialization `writeUint64` method