### PR TITLE
fix: issue computing asset properties size

### DIFF
--- a/__tests__/unit/core-nft/handlers/nft-mint.test.ts
+++ b/__tests__/unit/core-nft/handlers/nft-mint.test.ts
@@ -45,7 +45,7 @@ describe("should nft transaction handlers", () => {
         });
 
         // TODO: uns : unskip this test
-        it.skip("should pass all handler methods", async () => {
+        it("should pass all handler methods", async () => {
             await expect(
                 nftMinthandler.throwIfCannotBeApplied(nftMintTransaction.build(), senderWallet, walletManager),
             ).toResolve();
@@ -59,7 +59,7 @@ describe("should nft transaction handlers", () => {
 
         for (const propertiesAsset of propertiesAssets) {
             // TODO: uns : unskip this test + identify each test case in for loop
-            it.skip("should pass all handler methods, with properties", async () => {
+            it("should pass all handler methods, with properties", async () => {
                 const transaction = nftMintTransaction.properties(propertiesAsset).build();
                 await expect(
                     nftMinthandler.throwIfCannotBeApplied(transaction, senderWallet, walletManager),

--- a/packages/core-nft/src/transactions/handlers/helpers.ts
+++ b/packages/core-nft/src/transactions/handlers/helpers.ts
@@ -58,8 +58,8 @@ export const applyNftTransferDb = async (
 };
 
 export const checkAssetPropertiesSize = (properties: INftProperties) => {
-    for (const [key, value] of Object.entries(properties)) {
-        if (Buffer.from(value, "utf8").length > 255) {
+    for (const [key, value] of Object.entries(properties || {})) {
+        if (value && Buffer.from(value, "utf8").length > 255) {
             throw new NftPropertyTooLongError(key);
         }
     }


### PR DESCRIPTION
Refactor of `checkAssetPropertiesSize` utility function caused test failures. 
This PR fixes broken code in `checkAssetPropertiesSize`.
All tests of `unit/core-nft` should be unskipped and successful.