### PR TITLE
remove forced transaction version in nft builder

### DIFF
--- a/packages/core-nft-crypto/src/builders/nft.ts
+++ b/packages/core-nft-crypto/src/builders/nft.ts
@@ -4,7 +4,6 @@ import { NftTransactionGroup, NftTransactionType } from "../enums";
 export abstract class NftBuilder<T extends NftBuilder<T>> extends Transactions.TransactionBuilder<NftBuilder<T>> {
     constructor(protected nftName: string, tokenId: string) {
         super();
-        this.data.version = 2;
 
         this.data.amount = Utils.BigNumber.ZERO;
         this.data.senderPublicKey = undefined;


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

Removes version of transaction forced to "2".
The version is already set by the TransactionBuilder constructor
