### PR TITLE
Add new ghost package ark-crypto for npm publications

### DIFF
--- a/packages/core-nft-crypto/package.json
+++ b/packages/core-nft-crypto/package.json
@@ -16,7 +16,10 @@
         "build:watch": "yarn clean && yarn compile -w",
         "clean": "del dist",
         "compile": "../../node_modules/typescript/bin/tsc",
-        "prepublishOnly": "yarn build"
+        "restore_backup": "mv package.json.back package.json",
+        "uns_rebrand": "../../scripts/uns_publish_rebrand.sh $PWD",
+        "prepublishOnly": "yarn build && yarn uns_rebrand",
+        "postpublish": "yarn restore_backup"
     },
     "dependencies": {
         "@arkecosystem/crypto": "^2.6.0-next.4",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@arkecosystem/crypto",
     "version": "2.6.0-next.4",
+    "uns_version": "4.0.0-dev",
     "description": "Crypto utilities for the ARK Blockchain",
     "license": "MIT",
     "contributors": [
@@ -24,7 +25,10 @@
         "build:watch": "yarn clean && yarn compile -w",
         "clean": "del dist",
         "compile": "../../node_modules/typescript/bin/tsc",
-        "prepublishOnly": "yarn build"
+        "uns_prepublish": "../../scripts/ark_crypto_publish.sh $PWD",
+        "restore_backup": "mv package.json.back package.json",
+        "prepublishOnly": "yarn build && yarn uns_prepublish",
+        "postpublish": "yarn restore_backup"
     },
     "dependencies": {
         "@arkecosystem/utils": "0.8.3",

--- a/packages/uns-crypto/package.json
+++ b/packages/uns-crypto/package.json
@@ -20,7 +20,10 @@
         "build:watch": "yarn clean && yarn compile -w",
         "clean": "del dist",
         "compile": "../../node_modules/typescript/bin/tsc",
-        "prepublishOnly": "yarn build"
+        "restore_backup": "mv package.json.back package.json",
+        "uns_rebrand": "../../scripts/uns_publish_rebrand.sh $PWD",
+        "prepublishOnly": "yarn build && yarn uns_rebrand",
+        "postpublish": "yarn restore_backup"
     },
     "dependencies": {
         "@arkecosystem/crypto": "^2.6.0-next.4"

--- a/scripts/ark_crypto_publish.sh
+++ b/scripts/ark_crypto_publish.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+#backup package.json
+cp "$1/package.json" "$1/package.json.back"
+
+uns_name="ark-crypto"
+ark_crypto_version=$(sed -n 's/\"uns_version\": \"\(.*\)\"\,\?/\1/p' "$1/package.json" | tr -d '[:space:]')
+echo "Publishing @uns/$uns_name $ark_crypto_version"
+#replace name in package.json
+sed -i "s/\"name\": \"\(.*\)\"/\"name\": \"@uns\/$uns_name\"/g" "$1/package.json"
+#replace version
+sed -i "s/\"version\": \"\(.*\)\"/\"version\": \"$ark_crypto_version\"/g" "$1/package.json"

--- a/scripts/uns_publish_rebrand.sh
+++ b/scripts/uns_publish_rebrand.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+uns_base_package="$uns_base_package"
+echo "Remaping @arkecosystem/crypto to @uns/$uns_base_package"
+
+#backup package.json
+cp "$1/package.json" "$1/package.json.back"
+
+package_name=$(basename $1)
+case $package_name in
+    uns-crypto|core-nft-crypto)
+        for file in $(grep -r '@arkecosystem/crypto' "$1/dist" | cut -d':' -f1)
+        do
+            if [[ ( $file == *.js ) || ( $file == *.d.ts ) ]]
+            then
+                sed -i 's/@arkecosystem\/crypto/@uns\/$uns_base_package/g' $file
+            fi
+        done
+
+        ark_crypto_version=$(sed -n 's/\"uns_version\": \"\(.*\)\"\,\?/\1/p' "$1/../crypto/package.json" | tr -d '[:space:]')
+        if [ -n "$ark_crypto_version" ]
+        then
+            echo "Set @uns/$uns_base_package dependency to version $ark_crypto_version"
+            sed -i "s/\"@arkecosystem\/crypto\": \".*\"/\"@uns\/$uns_base_package\": \"\^$ark_crypto_version\"/g" "$1/package.json"
+        else
+            echo "Unable to retrieve @uns/$uns_base_package version"
+            exit 1
+        fi;;
+    *)
+        echo "Unknown UNS package $package_name"
+        exit 1;;
+esac
+


### PR DESCRIPTION
<!-- Please don't delete this template and read our contribution guidelines at https://docs.ark.io/guidebook/contribution-guidelines/contributing.html -->

## Summary

Sources of this packages are the same as the local @arkecosystem/crypto package. (i.e src/ is a symlink to ../crypto/src).
This package is used for publication on NPM only. It is intended to be used in the UNS typescript ecosystem including @uns/cli, @uns/ts-dsk...
