### PR TITLE
chores: improve dalinet auto update

### DIFF
--- a/scripts/upstream/update-upstream.sh
+++ b/scripts/upstream/update-upstream.sh
@@ -28,8 +28,8 @@ cd $WORKDIR
 
 DOCKER_COMPOSE_FILE_PATH=$SOURCES_PATH/docker/integration/docker-compose.yml
 
-docker-compose -f $DOCKER_COMPOSE_FILE_PATH down 
-
 docker-compose -f $DOCKER_COMPOSE_FILE_PATH up --build -d
+
+docker images prune -f
 
 exit 0


### PR DESCRIPTION
## Why

- prevent manual restart of dalinet node
- prevent build error `No space left on device`
- downside : we won't be notified of future build crashes

## DONE

- remove step `down` to prevent downtime
- prune dangling images (i.e image neither tagged nor used by a container)