### PR TITLE
refactor: change voucher rewards

### DIFF
--- a/packages/crypto/src/networks/dalinet/milestones.json
+++ b/packages/crypto/src/networks/dalinet/milestones.json
@@ -68,5 +68,30 @@
         "height": 3600,
         "disableArkLegacyVote": true,
         "urlCheckers": ["88f19a6b1d0d2ca16d385f7f76ba343234fd87498a723439a3b6cf79b38431bc"]
+    },
+    {
+        "height": 1194000,
+        "voucherRewards": {
+            "individual": {
+                "forger": 1000000000,
+                "sender": 1000000000,
+                "foundation": 8000000000
+            },
+            "organization": {
+                "forger": 1000000000,
+                "sender": 10000000000,
+                "foundation": 989000000000
+            },
+            "network": {
+                "forger": 1000000000,
+                "sender": 100000000000,
+                "foundation": 99899000000000
+            }
+        },
+        "fees": {
+            "staticFees": {
+                "UnsCertifiedNftMint": 1000000000
+            }
+        }
     }
 ]

--- a/packages/crypto/src/networks/livenet/milestones.json
+++ b/packages/crypto/src/networks/livenet/milestones.json
@@ -80,6 +80,28 @@
         "p2p": {
             "minimumVersions": ["^5.4.0 || ^5.4.0-dev"]
         },
-        "urlCheckers": ["08bf335ede1818e222ecd529e0e892190aab62a39ec40492395b825a4f640731"]
+        "urlCheckers": ["08bf335ede1818e222ecd529e0e892190aab62a39ec40492395b825a4f640731"],
+        "voucherRewards": {
+            "individual": {
+                "forger": 1000000000,
+                "sender": 1000000000,
+                "foundation": 8000000000
+            },
+            "organization": {
+                "forger": 1000000000,
+                "sender": 10000000000,
+                "foundation": 989000000000
+            },
+            "network": {
+                "forger": 1000000000,
+                "sender": 100000000000,
+                "foundation": 99899000000000
+            }
+        },
+        "fees": {
+            "staticFees": {
+                "UnsCertifiedNftMint": 1000000000
+            }
+        }
     }
 ]

--- a/packages/crypto/src/networks/sandbox/milestones.json
+++ b/packages/crypto/src/networks/sandbox/milestones.json
@@ -77,6 +77,28 @@
         "p2p": {
             "minimumVersions": ["^5.4.0 || ^5.4.0-dev"]
         },
-        "urlCheckers": ["fcc385b9a0bf840525242c2248312988efba5ea5e03bec84cebb5c8265f56059"]
+        "urlCheckers": ["fcc385b9a0bf840525242c2248312988efba5ea5e03bec84cebb5c8265f56059"],
+        "voucherRewards": {
+            "individual": {
+                "forger": 1000000000,
+                "sender": 1000000000,
+                "foundation": 8000000000
+            },
+            "organization": {
+                "forger": 1000000000,
+                "sender": 10000000000,
+                "foundation": 989000000000
+            },
+            "network": {
+                "forger": 1000000000,
+                "sender": 100000000000,
+                "foundation": 99899000000000
+            }
+        },
+        "fees": {
+            "staticFees": {
+                "UnsCertifiedNftMint": 1000000000
+            }
+        }
     }
 ]

--- a/plugins/uns/uns-crypto/src/builders/uns-certified-nft-mint.ts
+++ b/plugins/uns/uns-crypto/src/builders/uns-certified-nft-mint.ts
@@ -1,7 +1,7 @@
-import { Utils } from "@arkecosystem/crypto";
 import { Builders } from "@uns/core-nft-crypto";
-import { UnsTransactionGroup, UnsTransactionStaticFees, UnsTransactionType } from "../enums";
+import { UnsTransactionGroup, UnsTransactionType } from "../enums";
 import { INftMintDemandCertification, INftMintDemandPayload } from "../interfaces";
+import { CertifiedNftMintTransaction } from "../transactions";
 import { applyMixins } from "../utils";
 import { IUNSCertifiedNftBuilder, UNSCertifiedNftBuilder } from "./uns-certified-nft-common";
 
@@ -11,7 +11,7 @@ export class UNSCertifiedNftMintBuilder extends Builders.NftMintBuilder {
     }
 
     protected fees() {
-        return Utils.BigNumber.make(UnsTransactionStaticFees.UnsCertifiedNftMint);
+        return CertifiedNftMintTransaction.staticFee();
     }
 
     protected type() {


### PR DESCRIPTION
Probleme identifié: on est pas capable aujourd'hui de mettre des fees différents selon le type d'unik qu'on mint.
Le souci est que la methode fees du builder peu etre appelé (et elle l'est) avant que l'asset ne soit seté et on a donc pas connaissance du type de unik est demandé.
Si vous préférez il y a un workaround un peu sale qui est de setter les fees dans la methode certification() du builder. à ce moment la on à accès au type est on est sur qu'il ne changera pas car la signature de l'asset est dans la certification..
what do you think ?? 