### PR TITLE
feat: compute current total supply from wallet balances

### DIFF
--- a/__tests__/functional/transaction-forging/uns/certified-mint.test.ts
+++ b/__tests__/functional/transaction-forging/uns/certified-mint.test.ts
@@ -79,7 +79,8 @@ describe("Uns certified mint", () => {
         const premine = parseInt(genesisBlock.totalAmount);
         const totalSupply = response.data.data.supply;
         const blockReward = Managers.configManager.getMilestone().reward;
-        const totalBlockRewards = response.data.data.block.height * blockReward;
+        // Block 1 (genesis) has no block reward
+        const totalBlockRewards = (response.data.data.block.height - 1) * blockReward;
         expect(+totalSupply).toEqual(
             premine + totalBlockRewards + rewards.sender + rewards.forger + rewards.foundation,
         );

--- a/packages/core-api/src/handlers/blockchain/controller.ts
+++ b/packages/core-api/src/handlers/blockchain/controller.ts
@@ -1,19 +1,16 @@
-import { supplyCalculator } from "@arkecosystem/core-utils";
-import { Utils } from "@arkecosystem/crypto";
+import { app } from "@arkecosystem/core-container";
+import { Database } from "@arkecosystem/core-interfaces";
 import Boom from "@hapi/boom";
 import Hapi from "@hapi/hapi";
-import { nftsRepository } from "../../core-nft/handlers/methods";
 import { Controller } from "../shared/controller";
 
 export class BlockchainController extends Controller {
     public async index(request: Hapi.Request, h: Hapi.ResponseToolkit) {
         try {
-            const lastBlock = this.blockchain.getLastBlock();
+            const databaseService = app.resolvePlugin<Database.IDatabaseService>("database");
 
-            const rewardSupply: Utils.BigNumber = await nftsRepository.getNftTotalRewards(lastBlock.data.height);
-            const supply = Utils.BigNumber.make(supplyCalculator.calculate(lastBlock.data.height))
-                .plus(rewardSupply)
-                .toFixed();
+            const lastBlock = this.blockchain.getLastBlock();
+            const supply = databaseService.walletManager.getTotalSupply().toFixed();
             return {
                 data: {
                     block: {

--- a/packages/core-interfaces/src/core-state/wallets.ts
+++ b/packages/core-interfaces/src/core-state/wallets.ts
@@ -151,6 +151,8 @@ export interface IWalletManager {
     hasByPublicKey(publicKey: string): boolean;
 
     hasByUsername(username: string): boolean;
+
+    getTotalSupply(): Utils.BigNumber;
 }
 
 export interface IWalletIndex {

--- a/packages/core-state/src/wallets/wallet-manager.ts
+++ b/packages/core-state/src/wallets/wallet-manager.ts
@@ -584,6 +584,17 @@ export class WalletManager implements State.IWalletManager {
     }
 
     /**
+     * Get total supply.
+     */
+    public getTotalSupply(): Utils.BigNumber {
+        const premineSupply: string = app.getConfig().get("genesisBlock.totalAmount");
+        const addBalance = (accumulator: Utils.BigNumber, wallet: State.IWallet) => accumulator.plus(wallet.balance);
+        return this.allByAddress()
+            .reduce(addBalance, Utils.BigNumber.ZERO)
+            .plus(Utils.BigNumber.make(premineSupply));
+    }
+
+    /**
      * Updates the vote balances of the respective delegates of sender and recipient.
      * If the transaction is not a vote...
      *    1. fee + amount is removed from the sender's delegate vote balance


### PR DESCRIPTION
Execution time of supply computation benchmarked on my laptop:
with previous implementation:
951.221ms
With new implem:
4.415ms